### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Longer reasoning on what strategy was chosen and how it was implemented.
 
 ## Type of change
 
-Please delete options that are not relevant.
+Please DELETE options that are not relevant (so that github pr list would report that all tasks have been completed)
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -19,17 +19,12 @@ Please delete options that are not relevant.
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+Please DELETE options that are not relevant (so that github pr list would report that all tasks have been completed)
 
 - [ ] Unit tests
 - [ ] Integration tests
 - [ ] Type tests (via example declarations + ts-expect-error examples)
 - [ ] Tested manually (ADD REASON WHY MANUALLY)
 - [ ] Not tested (ADD REASON WHY NOT TESTED)
-
-# Checklist:
-
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
 
 [^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
-# Motivation
-
-Short explanation on why this change is needed and reference to ticket (link created automatically): TICKET-123
-
 # Description[^1]
 
-Please include a summary of the change and which issue is fixed. Please also include relevant context on choices that you made. 
+**Have some feature do something**
 
-List any dependencies that are required for this change.
+Longer reasoning (does not have to be wall of text) on what strategy was chosen and how it was implemented.
+
+**Have existing feature no longer break**
+
+Longer reasoning on what strategy was chosen and how it was implemented.
 
 ## Type of change
 
@@ -15,7 +15,7 @@ Please delete options that are not relevant.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Maintenance (changes meta-data or package setup)
+- [ ] Maintenance (changes meta-data, package setup or readme)
 
 # How Has This Been Tested?
 
@@ -23,14 +23,13 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 - [ ] Unit tests
 - [ ] Integration tests
-- [ ] Tested manually (in some context, provide more details)
 - [ ] Type tests (via example declarations + ts-expect-error examples)
+- [ ] Tested manually (ADD REASON WHY MANUALLY)
+- [ ] Not tested (ADD REASON WHY NOT TESTED)
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My changes generate no new warnings
-- [ ] New and existing unit tests pass locally with my changes
 
 [^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,6 @@ Please DELETE options that are not relevant (so that github pr list would report
 - [ ] Integration tests
 - [ ] Type tests (via example declarations + ts-expect-error examples)
 - [ ] E2E tests (provide PR if new tests)
-- [ ] Contract tests
 - [ ] Tested manually (ADD REASON WHY)
 - [ ] Not tested (ADD REASON WHY)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,8 @@ Please DELETE options that are not relevant (so that github pr list would report
 - [ ] Unit tests
 - [ ] Integration tests
 - [ ] Type tests (via example declarations + ts-expect-error examples)
+- [ ] E2E tests (provide PR if new tests)
+- [ ] Contract tests
 - [ ] Tested manually (ADD REASON WHY MANUALLY)
 - [ ] Not tested (ADD REASON WHY NOT TESTED)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Please DELETE options that are not relevant (so that github pr list would report
 - [ ] Type tests (via example declarations + ts-expect-error examples)
 - [ ] E2E tests (provide PR if new tests)
 - [ ] Contract tests
-- [ ] Tested manually (ADD REASON WHY MANUALLY)
-- [ ] Not tested (ADD REASON WHY NOT TESTED)
+- [ ] Tested manually (ADD REASON WHY)
+- [ ] Not tested (ADD REASON WHY)
 
 [^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)


### PR DESCRIPTION
# Description[^1]

**Have no always-check checkboxes as part of the pull-request**

Some parts of the template were kind of useless where one had no other chance but to actually tick the checkboxes (examples: we use linter, so there's no way to mess up the code styling; tests pass locally). 

**Have no overlap/confusion on what should be written in each section**

The "motivation" block was kind of overlapping with description where in some cases it was just easier for people to delete the Motivation part and only go with Description. As such, am proposing that we merge them where motivation is presented in short sentences that are made to stand out by bolding them in.

## Questions

1. Should we keep "type of change"? Does it bring any value? One can anyways communicate that in branch prefix or in Description (and in CHANGELOG.md)
2. Does it matter how it was tested as we generally have pretty good standards in terms of people not pushing untested code to production (+ if someone checks a box .. what does it really change? there can still be untested code).

## Type of change

- [x] Maintenance (changes meta-data or package setup)

# How Has This Been Tested?

- [x] Not Tested (just a template change)

[^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)
