### PR TITLE
Maintenance: reduce template filling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,15 @@
 # Description[^1]
 
-**Have some feature do something**
+**Short heading on why the change is necessary**
 
-Longer reasoning (does not have to be wall of text) on what strategy was chosen and how it was implemented.
-
-**Have existing feature no longer break**
-
-Longer reasoning on what strategy was chosen and how it was implemented.
+Describe the approach you took. 
+If simple, keep it short. 
+If complex, provide more details.
 
 # How Has This Been Tested?
 
-- [ ] Test automation
-- [ ] Tested manually (ADD REASON WHY)
-- [ ] Not tested (ADD REASON WHY)
+- [ ] Automation
+- [ ] Tested manually (add a reason)
+- [ ] Not tested (add a reason)
 
-[^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)
+[^1]: Conducting a review [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,23 +8,11 @@ Longer reasoning (does not have to be wall of text) on what strategy was chosen 
 
 Longer reasoning on what strategy was chosen and how it was implemented.
 
-## Type of change
-
-Please DELETE options that are not relevant (so that github pr list would report that all tasks have been completed)
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Maintenance (changes meta-data, package setup or readme)
-
 # How Has This Been Tested?
 
 Please DELETE options that are not relevant (so that github pr list would report that all tasks have been completed)
 
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Type tests (via example declarations + ts-expect-error examples)
-- [ ] E2E tests (provide PR if new tests)
+- [ ] Test automation
 - [ ] Tested manually (ADD REASON WHY)
 - [ ] Not tested (ADD REASON WHY)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,6 @@ Longer reasoning on what strategy was chosen and how it was implemented.
 
 # How Has This Been Tested?
 
-Please DELETE options that are not relevant (so that github pr list would report that all tasks have been completed)
-
 - [ ] Test automation
 - [ ] Tested manually (ADD REASON WHY)
 - [ ] Not tested (ADD REASON WHY)


### PR DESCRIPTION
# Description[^1]

**Have less time spent when opening a PR**

Parts of the template could be considered redundant as the "type of change" could be described within the PR title or in the branch name (which I'd take most are already doing).

The information itself is not really used for anything and for a reviewer - it does not really make much difference if the PR is feature or fix PR.

**Have more focus on non-standard cases in how-dis-tested**

Grouped all the happy-path options together for testing related question for the sake of focusing more on situations where something that is expected would not be part of the changes.

Namely: the options left relate to manual testing or testing being skipped which hopefully makes the engineer contemplate for a second why they skipped such a crucial thing as test automation (and hopefully they have a good explanation why they chose that path).

## Type of change

- [x] Maintenance (changes meta-data, package setup or readme)

# How Has This Been Tested?

- [x] Not tested (markdown template change that only executes in other PRs; nothing really to test here)

[^1]: Here is how to conduct a [code review](https://katanaos.atlassian.net/wiki/spaces/EN/pages/82116626/How+to+conduct+Code+Review)
